### PR TITLE
Add prod env in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 backuper
 ========
 
-A Symfony project created on November 5, 2015, 10:30 am.
-
 Deploy it on the server hosting the mysql database you want to backup.
 
 Then, add this kind of crontab job:

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Deploy it on the server hosting the mysql database you want to backup.
 Then, add this kind of crontab job:
 
 ```
-0 0 * * * env SYMFONY__BACKUP__DIRECTORY="[path to backup directory]" SYMFONY__DATABASE_NAME="[database name]" SYMFONY__DATABASE_USER="[database user]" SYMFONY__DATABASE_PASSWORD="[database password]"  php [path to sources]/app/console dizda:backup:start
+0 0 * * * env SYMFONY__BACKUP__DIRECTORY="[path to backup directory]" SYMFONY__DATABASE_NAME="[database name]" SYMFONY__DATABASE_USER="[database user]" SYMFONY__DATABASE_PASSWORD="[database password]"  php [path to sources]/app/console dizda:backup:start --env=prod
 ```


### PR DESCRIPTION
According to https://github.com/dizda/CloudBackupBundle/blob/master/Command/BackupCommand.php#L52, this command should fail if you don't specify a prod environment.